### PR TITLE
Set the component popup menu of the mask test pane

### DIFF
--- a/src/spiral/SpiralGenerator.form
+++ b/src/spiral/SpiralGenerator.form
@@ -209,6 +209,11 @@
                       <Layout class="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout"/>
                       <SubComponents>
                         <Component class="javax.swing.JTextPane" name="maskTextPane">
+                          <Properties>
+                            <Property name="componentPopupMenu" type="javax.swing.JPopupMenu" editor="org.netbeans.modules.form.ComponentChooserEditor">
+                              <ComponentRef name="maskPopup"/>
+                            </Property>
+                          </Properties>
                           <Constraints>
                             <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout" value="org.netbeans.modules.form.compat2.layouts.DesignBorderLayout$BorderConstraintsDescription">
                               <BorderConstraints direction="Center"/>

--- a/src/spiral/SpiralGenerator.java
+++ b/src/spiral/SpiralGenerator.java
@@ -928,6 +928,8 @@ public class SpiralGenerator extends javax.swing.JFrame implements DebugCapable{
         });
 
         maskTextPanel.setLayout(new java.awt.BorderLayout());
+
+        maskTextPane.setComponentPopupMenu(maskPopup);
         maskTextPanel.add(maskTextPane, java.awt.BorderLayout.CENTER);
 
         maskTextScrollPane.setViewportView(maskTextPanel);


### PR DESCRIPTION
I've set the component popup menu for the mask text pane. This was accidentally removed when updating the text area used for the mask text.